### PR TITLE
Fixed log in error

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -11,10 +11,6 @@ class ApplicationController < ActionController::Base
     devise_parameter_sanitizer.permit(:account_update, keys: %i[first_name last_name])
   end
 
-  def after_sign_in_path_for(_resource)
-    weather_today_path
-  end
-
   def disable_nav
     @disable_nav = true
   end


### PR DESCRIPTION
When logging in was getting an error because the  weather today path doesn't exist any more.
![image](https://github.com/DanieleTrapani/dailyfits/assets/116356064/de70cf2c-1cbf-4c2d-a23a-06af2f0ed6fa)
I removed the after sign in path because the routes file has a different root when the user is logged in.
```
devise_for :users
unauthenticated do
  devise_scope :user do
    root "pages#home", as: :unauthenticated_root
  end
end
authenticated :user do
  root to: "home#index", as: :root
end
```